### PR TITLE
BugFix：修复并发启动概率性任务未执行完的问题

### DIFF
--- a/anchortasklibrary/src/main/java/com/xj/anchortask/library/IAnchorTask.kt
+++ b/anchortasklibrary/src/main/java/com/xj/anchortask/library/IAnchorTask.kt
@@ -106,6 +106,7 @@ abstract class AnchorTask(private val name: String) : IAnchorTask {
         countDownLatch.await()
     }
 
+    @Synchronized
     private fun tryToInitCountDown() {
         if (!this::countDownLatch.isInitialized) {
             countDownLatch = CountDownLatch(dependList.size)


### PR DESCRIPTION
使用此框架，出现启动10次大概率1次任务未全部执行，导致一致await。发现是CountDownLatch多次初始化导致